### PR TITLE
Fixing the TO functions for issue #13

### DIFF
--- a/bot/nanochan.py
+++ b/bot/nanochan.py
@@ -38,6 +38,7 @@ class Nanochan(Bot):
         self.wait_time = config['wait_time']
         self.clover_days = config['clover_days']
         self.dm_forward = config['dm_forward']
+        self.timeout_id = config['timeout_id']
         self.logger = logger
         super().__init__('-')
 

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -99,13 +99,12 @@ class Moderation:
     @commands.command()
     @checks.has_permissions(manage_roles=True)
     async def timeout(self, ctx, member: discord.Member):
-        timeout_id = 195717833789800448
         guild_roles = ctx.guild.roles
-        timeout_role = find(lambda m: m.id == timeout_id, guild_roles)
+        timeout_role = ctx.guild.get_role(self.bot.timeout_id)
         confirm = await helpers.confirm(ctx, member, '')
         if confirm:
             try:
-                # await member.add_roles(timeout_role)
+                await member.add_roles(timeout_role)
                 all_channels = await self.bot.postgres_controller.get_all_channels()
                 for row in all_channels:
                     channel = self.bot.get_channel(row['host_channel'])
@@ -139,18 +138,15 @@ class Moderation:
     @commands.command()
     @checks.has_permissions(manage_roles=True)
     async def untimeout(self, ctx, member: discord.Member):
-        timeout_id = 195717833789800448
         guild_roles = ctx.guild.roles
-        timeout_role = find(lambda m: m.id == timeout_id, guild_roles)
+        timeout_role = ctx.guild.get_role(self.bot.timeout_id)
         confirm = await helpers.confirm(ctx, member, '')
         if confirm:
             try:
                 await member.remove_roles(timeout_role)
                 all_channels = await self.bot.postgres_controller.get_all_channels()
-                print(all_channels)
                 for row in all_channels:
-                    print(row)
-                    channel = await self.bot.get_channel(row['host_channel'])
+                    channel = self.bot.get_channel(row['host_channel'])
                     message = await channel.get_message(row['message_id'])
                     reacted_users = await message.reactions[0].users().flatten()
                     if member in reacted_users:

--- a/config/config.yml
+++ b/config/config.yml
@@ -8,6 +8,8 @@ owner_id: 164546159140929538
 
 mod_info: 378684962934751239
 
+timeout_id: 
+
 dm_forward:
     - 123456789 # Me
 


### PR DESCRIPTION
Towards issue #13 
I added the field `timeout_id` to the config.yml file to make it more generalized or easier to manipulate. I also updated the timeout and untimeout commands to properly apply and remove the role respectively while handling the permissions for the assign channels. This is using the implementation number 1 in  the aforementioned issue number that Dash laid out.