### PR TITLE
Attempt to fix mods being stupid

### DIFF
--- a/cogs/filter.py
+++ b/cogs/filter.py
@@ -37,7 +37,7 @@ class Filter(commands.Cog):
                 mod_info = self.bot.get_channel(259728514914189312)
                 await mod_info.send(
                     f'**{time} | SPAM:** {message.author} has had {user_deleted} '\
-                    f'messages deleted in #join-logs'
+                    f'messages deleted in {message.channel.name}'
                 )
             self.bot.logger.info(
                 'Successfully deleted message from: '


### PR DESCRIPTION
I tried to make it so nano says the channel the message was deleted in instead of always saying #join-logs because that was my last fix and it might get to be a bit much to change one line every time we rename or change the channel.

As always I have no clue if it works or not but lets push to production!