### PR TITLE
Channelmessagecache

### DIFF
--- a/bot/nanochan.py
+++ b/bot/nanochan.py
@@ -63,7 +63,7 @@ class Nanochan(Bot):
         postgres_controller = await PostgresController.get_instance(
             logger=logger, connect_kwargs=postgres_cred)
         chanreact = await postgres_controller.get_all_channels()
-        chanreact = [(x[2], x[1]) for x in chanreact]  # cache the react channel_message as host_channel, message_id
+        chanreact = [tuple(x) for x in chanreact]  # cache the react channel_message as target_channel, message_id, host_channel
         return cls(config, misc_config, logger, False, postgres_controller, chanreact)
 
     @classmethod

--- a/bot/nanochan.py
+++ b/bot/nanochan.py
@@ -16,7 +16,7 @@ class Nanochan(Bot):
     actual bot class
     """
     def __init__(self, config, misc_config, logger, test,
-                 postgres_controller: PostgresController):
+                 postgres_controller: PostgresController, chanreact):
         """
         init for bot class
         """
@@ -40,6 +40,7 @@ class Nanochan(Bot):
         self.dm_forward = config['dm_forward']
         self.timeout_id = misc_config['timeout_id']
         self.logger = logger
+        self.chanreact = chanreact
         super().__init__('-')
 
     @classmethod
@@ -61,7 +62,9 @@ class Nanochan(Bot):
         postgres_cred = config['postgres_credentials']
         postgres_controller = await PostgresController.get_instance(
             logger=logger, connect_kwargs=postgres_cred)
-        return cls(config, misc_config, logger, False, postgres_controller)
+        chanreact = await postgres_controller.get_all_channels()
+        chanreact = [(x[2], x[1]) for x in chanreact]  # cache the react channel_message as host_channel, message_id
+        return cls(config, misc_config, logger, False, postgres_controller, chanreact)
 
     @classmethod
     async def get_test_instance(cls):

--- a/cogs/channels.py
+++ b/cogs/channels.py
@@ -100,15 +100,15 @@ class Channels(commands.Cog):
         if not message_id:
             return
         og_message = await ctx.channel.fetch_message(int(message_id))
-        users_to_remove = await self.bot.postgres_controller.get_chanreacts_fromchan(ctx.channel.id, target_channel.id)
-        for user_id in users_to_remove:
-            try:
-                user = self.bot.get_user(user_id)
-                if user.bot:
-                    continue
-                await self.remove_perms(user, target_channel)
-            except:
-                pass
+
+        try:
+            await self.rm_channel_chanreact(target_channel, ctx.channel.id)
+        except:
+            pass
+        try:
+            await target_channel.sync_permissions(True)
+        except:
+            pass
         await og_message.delete()
         await self.bot.postgres_controller.rem_channel_message(target_channel.id, ctx.channel.id)
         del self.bot.chanreact[self.bot.chanreact.index((target_channel.id, og_message.id, ctx.channel.id))]

--- a/cogs/channels.py
+++ b/cogs/channels.py
@@ -268,13 +268,12 @@ class Channels(commands.Cog):
             return
         target_channel = ([x for x in self.bot.chanreact if (x[-1], x[1]) == (payload.channel_id, payload.message_id)])[0][0]
         if not target_channel:
-            return 
+            return
         user = self.bot.get_user(payload.user_id)
         if user.bot:
             return
         channel = self.bot.get_channel(target_channel)
         reacts = await self.bot.postgres_controller.add_user_reaction(payload.user_id, payload.message_id)
-        """
         if int(reacts) in [10, 20, 100]:
             time = self.bot.timestamp()
             mod_info = self.bot.get_channel(259728514914189312)
@@ -282,7 +281,6 @@ class Channels(commands.Cog):
                 f'**{time} | REACTION SPAM:** {user} has reacted {reacts} '\
                 f'times today on the permission message for #{channel}'
             )
-        """
         await self.add_perms(user, channel)
         await self.bot.postgres_controller.add_user_chanreact(payload.user_id, payload.channel_id, payload.message_id, target_channel)
 
@@ -310,7 +308,7 @@ class Channels(commands.Cog):
         try:
             await channel.set_permissions(user, read_messages=True)
         except Exception as e:
-            self.bot.logger.warning(f'{e}') 
+            self.bot.logger.warning(f'{e}')
 
     async def remove_perms(self, user, channel):
         """
@@ -319,4 +317,4 @@ class Channels(commands.Cog):
         try:
             await channel.set_permissions(user, read_messages=False)
         except Exception as e:
-            self.bot.logger.warning(f'{e}') 
+            self.bot.logger.warning(f'{e}')

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -115,21 +115,15 @@ class Moderation(commands.Cog):
             except (HTTPException, AttributeError) as e:
                 reply += f'Error adding user to TO role: <@&{self.bot.timeout_id}>!: {str(e)}\nContinuing with restoring permissions to self-assign channels.\n'
                 pass
-            r = await self.bot.postgres_controller.get_all_chanreacts()
-            all_channels = []
-            for x in r:
-                if not isinstance(x['user_id'], type(None)):
-                    if member.id in x['user_id']:
-                        all_channels.append(x)
-            for row in all_channels:
-                self.bot.logger.info(f'{row}, {member.id}')
+            r = await self.bot.postgres_controller.get_chanreacts_fromuser(member.id)
+            r = [x['target_channel'] for x in r]
+            for target_channel in r:
                 try:
-                    target_channel = self.bot.get_channel(
-                        row['target_channel'])
+                    target_channel = self.bot.get_channel(target_channel)
                     await self.remove_perms(member, target_channel)
                     removed_from_channels.append(target_channel.name)
                 except (HTTPException, AttributeError) as e:
-                    self.bot.logger.warning(f'Error removing user from channel!: {row["target_channel"]}{e}')  # noqa
+                    self.bot.logger.warning(f'Error removing user from channel!: {target_channel} {e}')  # noqa
         except Exception as e:
             self.bot.logger.warning(f'Error timing out user!: {e}')
             await ctx.send('❌', delete_after=3)
@@ -159,21 +153,15 @@ class Moderation(commands.Cog):
             except (HTTPException, AttributeError) as e:
                 reply += f'Error removing user from TO role: <@&{self.bot.timeout_id}>!: {e}\nContinuing with restoring permissions to self-assign channels.\n'
                 pass
-            r = await self.bot.postgres_controller.get_all_chanreacts()
-            all_channels = []
-            for x in r:
-                if not isinstance(x['user_id'], type(None)):
-                    if member.id in x['user_id']:
-                        all_channels.append(x)
-            for row in all_channels:
-                self.bot.logger.info(f'{row}, {member.id}')
+            r = await self.bot.postgres_controller.get_chanreacts_fromuser(member.id)
+            r = [x['target_channel'] for x in r]
+            for target_channel in r:
                 try:
-                    target_channel = self.bot.get_channel(
-                        row['target_channel'])
+                    target_channel = self.bot.get_channel(target_channel)
                     await self.add_perms(member, target_channel)
                     removed_from_channels.append(target_channel.name)
                 except (HTTPException, AttributeError) as e:
-                    self.bot.logger.warning(f'Error adding user to channel!: {row["target_channel"]}{e}')  # noqa
+                    self.bot.logger.warning(f'Error adding user to channel!: {target_channel} {e}')  # noqa
         except Exception as e:
             self.bot.logger.warning(f'Error untiming out user!: {e}')
             await ctx.send('❌', delete_after=3)

--- a/cogs/utils/db_utils.py
+++ b/cogs/utils/db_utils.py
@@ -17,7 +17,7 @@ except ImportError:
 def parse_record(record: Record) -> Optional[tuple]:
     """
     Parse a asyncpg Record object to a tuple of values
-    :param record: the asyncpg Record object
+    :param record: theasyncpg Record object
     :return: the tuple of values if it's not None, else None
     """
     try:
@@ -754,6 +754,16 @@ class PostgresController():
             """.format(self.schema)
 
         return await self.pool.execute(sql, user_id, target_channel, host_channel)
+
+    async def rm_channel_chanreact(self, target_channel, host_channel):
+        """
+        Returns all of the reaction channels
+        """
+        sql = """
+            DELETE FROM {}.channel_react WHERE target_channel = $1 AND host_channel = $2;
+            """.format(self.schema)
+
+        return await self.pool.execute(sql, target_channel, host_channel)
 
     """
     User Reaction Spam Stuff


### PR DESCRIPTION
Main changes:
> in bot/nanochan.py: on bot load will cache all of the channel_message info from db. Quick accessing
> cog/util/db_utils.py: added new db table channel_react with reference to channel_index
  > With above added new functions for adding and removing rows from new table
> in cog/channel.py: fixing so everything tries against the cached info from the bot attribute. Then execs on the db .
> cog/moderation.py: updated the timeout and untimeout commands to reflect the new db table polling.