### PR TITLE
Blacklist global users

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           name: Does compile?
           command: |
             . venv/bin/activate
-            python run.py test & sleep 20 ; kill $!
+            python run.py test & sleep 20 && exit 0 ; kill $!
 
       - store_artifacts:
           path: test-reports

--- a/bot/nanochan.py
+++ b/bot/nanochan.py
@@ -85,7 +85,9 @@ class Nanochan(Bot):
         postgres_cred = config['postgres_credentials']
         postgres_controller = await PostgresController.get_instance(
             logger=logger, connect_kwargs=postgres_cred)
-        return cls(config, misc_config, logger, True, postgres_controller)
+        chanreact = await postgres_controller.get_all_channels()
+        chanreact = [tuple(x) for x in chanreact]  # cache the react channel_message as target_channel, message_id, host_channel
+        return cls(config, misc_config, logger, False, postgres_controller, chanreact)
 
     def start_bot(self, cogs):
         """

--- a/cogs/filter.py
+++ b/cogs/filter.py
@@ -15,6 +15,8 @@ class Filter(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self, message):
+        if message.author.id in self.bot.blglobal:
+            return
         if isinstance(message.channel, discord.DMChannel):
             return
         if message.channel.id not in self.channels:

--- a/cogs/janitor.py
+++ b/cogs/janitor.py
@@ -58,6 +58,8 @@ class Janitor(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self, message):
+        if message.author.id in self.bot.blglobal:
+            return
         if isinstance(message.channel, discord.DMChannel):
             return
         if message.author.bot:

--- a/cogs/logging.py
+++ b/cogs/logging.py
@@ -167,16 +167,21 @@ class Logging(commands.Cog):
         except:
             await ctx.send('Couldn\'t find this report :(', delete_after=10)
             return
+        report = report[0]
         content, attachments, responces = '', [], []
         if ':=:' in report['message']:
             content = report['message'].split(':=:')[0]
             attachments = report['message'].split(':=:')[1:]
             attachments[-1] = attachments[-1].split(';=;')[0]
+        elif ';=;' in report['message']:
+            content = report['message'].split(';=;')[0]
+        else:
+            content = report['message']
         if ';=;' in report['message']:
-            responces = report['message'].split(':=:')[-1].split(';=;')[1:]
+            responces = report['message'].split(';=;')[1:]
 
         local_embed = discord.Embed(
-            title=f'DM report from {report["user_id"]}:',
+            title=f'DM report from <@{report["user_id"]}>:',
             description=content
         )
         if len(attachments) > 0:

--- a/cogs/logging.py
+++ b/cogs/logging.py
@@ -16,6 +16,8 @@ class Logging(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self, message):
+        if message.author.id in self.bot.blglobal:
+            return
         if not isinstance(message.channel, discord.DMChannel):
             if message.channel.id != 429536153251741706:
                 return

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -137,7 +137,7 @@ class Owner(commands.Cog):
             await ctx.send(embed=embed)
 
     @blacklistglobaluser.command(name='add', pass_context=True)
-    async def _blgua(self, ctx: commands.Context, uids: str=None):
+    async def _blgua(self, ctx: commands.Context, *, uids: str=None):
         """Add user to global blacklist.
 
         Parameters
@@ -179,7 +179,7 @@ class Owner(commands.Cog):
             self.bot.logger.info(f'Error adding users to global blacklist {e}')
 
     @blacklistglobaluser.command(name='remove', aliases=['rem', 'del', 'rm'])
-    async def _blgur(self, ctx: commands.Context, uids: str=None):
+    async def _blgur(self, ctx: commands.Context, *, uids: str=None):
         """Removes a user from the blacklist.
 
         Parameters

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -100,5 +100,6 @@ class Owner(commands.Cog):
                         await self.bot.postgres_controller.set_report_message_content(report['report_id'], report_message)
                     except Exception as err:
                         pass # self.bot.logger.warning('Failed: {}'.format(err))
+            await ctx.send('Fixed the db')
 
         return

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -3,7 +3,7 @@ Misc commands that I want to run
 """ 
 import discord 
 from discord.ext import commands 
-from.utils import checks 
+from .utils import checks 
 
 
 class Owner(commands.Cog):
@@ -43,3 +43,62 @@ class Owner(commands.Cog):
                 await channel.send(f'{message}')
         except Exception as e:
             ctx.send('Error when trying to send fam')
+
+    @commands.command(hidden=True)
+    @commands.is_owner()
+    async def fixdb(self, ctx, correction: str):
+        """
+        This command is a highly custom command that will be used to help
+        rsync/fix the db when code is updated.
+
+        Parameters
+        ----------
+        corrections: str
+            This is a string with the name of the correction to run. The
+            current corrections are rebuildReport
+        Returns
+        -------
+        None
+        """
+        actions = ('rebuildReport',)
+        if correction not in actions:
+            await ctx.send('Your action {} was not found in the actionable list: {}'.format(correction, actions))
+            return
+        if correction == 'rebuildReport':
+            # Add column to table
+            sql = """
+                ALTER TABLE {}.user_reports
+                ADD COLUMN message TEXT;
+            """.format(self.bot.postgres_controller.schema)
+            try:
+                await self.bot.postgres_controller.pool.execute(sql)
+            except Exception as err:
+                # await ctx.send('Couldn\'t add column to db: {}'.format(err), delete_after=15)
+                pass
+            # gather all user reports
+            user_reports = []
+            try:
+                user_reports = await self.bot.postgres_controller.get_all_user_reports()
+            except Exception as err:
+                # await ctx.send(err, delete_after=15)
+                pass
+            # Now go through and grab message contents
+            for report in user_reports:
+                # self.bot.logger.info(f'Fixing report {report["report_id"]}')
+                # self.bot.logger.info(f'Report {report}')
+                report_message = ''
+                try:
+                    report_message = await ctx.channel.fetch_message(int(report['message_id']))
+                    # self.bot.logger.info(f'Message {report_message}')
+                    report_message = report_message.embeds[0].description
+                except Exception as err:
+                    # await ctx.send(err, delete_after=15)
+                    pass
+                # self.bot.logger.info(report_message)
+                if report_message != '':
+                    try:
+                        await self.bot.postgres_controller.set_report_message_content(report['report_id'], report_message)
+                    except Exception as err:
+                        pass # self.bot.logger.warning('Failed: {}'.format(err))
+
+        return

--- a/cogs/reactions.py
+++ b/cogs/reactions.py
@@ -79,6 +79,8 @@ class Reactions(commands.Cog):
         """
         Actually responds with the reaction
         """
+        if message.author.id in self.bot.blglobal:
+            return
         if not message.channel.id in ALLOWED_CHANNELS:
             return
         if self.triggers is None:


### PR DESCRIPTION
Handles issue #32 
Added a new command group `blacklistglobaluser` which can be called with `blgu`
it has 2 (3) subfunctions, itself, add, and remove.
Calling `blgu` will list everyone in the blacklist
You can call blgu add or rem with mentionable, ids, or comma separate values of the above to add and remove users as needed. 

Also added a new table to reflect this new info
Added caching so only 1 db request at bot start and whenever the add/rem command is called. Otherwise just directly compares to the hash list for speed.