### PR TITLE
Feature/anonreport

### DIFF
--- a/bot/nanochan.py
+++ b/bot/nanochan.py
@@ -1,7 +1,7 @@
 """
 Discord bot that spaces out spoiler comments
 """
-import yaml
+import gila
 import os
 import discord
 from discord.ext.commands import Bot
@@ -56,10 +56,15 @@ class Nanochan(Bot):
         """
         async method to initialize the pg_controller class
         """
-        with open("config/config.yml", 'r') as yml_config:
-            config = yaml.load(yml_config)
-        with open("config/misc_config.yml", 'r') as yml_config:
-            misc_config = yaml.load(yml_config)
+        config = gila.Gila()
+        misc_config = gila.Gila()
+        config.set_config_file('config/config.yml')
+        misc_config.set_config_file('config/misc_config.yml')
+        config.read_config_file()
+        misc_config.read_config_file()
+        config = config.all_config()
+        misc_config = misc_config.all_config()
+
         logger = getLogger('nanochan')
         console_handler = StreamHandler()
         console_handler.setFormatter(Formatter(
@@ -80,10 +85,14 @@ class Nanochan(Bot):
         """
         async method to everything except the pg_controller
         """
-        with open("config/config.yml", 'r') as yml_config:
-            config = yaml.load(yml_config)
-        with open("config/misc_config.yml", 'r') as yml_config:
-            misc_config = yaml.load(yml_config)
+        config = gila.Gila()
+        misc_config = gila.Gila()
+        config.set_config_file('config/config.yml')
+        misc_config.set_config_file('config/misc_config.yml')
+        config.read_config_file()
+        misc_config.read_config_file()
+        config = config.all_config()
+        misc_config = misc_config.all_config()
         logger = getLogger('nanochan')
         console_handler = StreamHandler()
         console_handler.setFormatter(Formatter(

--- a/cogs/fightclub.py
+++ b/cogs/fightclub.py
@@ -211,6 +211,7 @@ class Fightclub(commands.Cog):
                     team_2_users += 1
                 if entry['userid'] == 164546159140929538:
                     # never used; god_emperor = entry['elo']
+                    pass
             total_aggro_r = self.ratio(total_aggro_w, total_aggro_l)
             total_def_r = self.ratio(total_def_w, total_def_l)
             #never used; top_5_aggro = sorted(full_list, key=lambda user: user['aggrowins'], reverse=True)[:5]
@@ -219,7 +220,7 @@ class Fightclub(commands.Cog):
             local_embed.add_field(name='Top 10 (by score)', value=(
                 await self.get_member_string(ctx.guild, 'elo', full_elo[:10])))
             local_embed.add_field(name='Team Scores',
-                value=f('Mealies elo: {team_1_elo:.2f}\nStealies elo: {team_2_elo:.2f}')
+                value=f('Mealies elo: {team_1_elo:.2f}\nStealies elo: {team_2_elo:.2f}'))
             await ctx.send(embed=local_embed)
             return
         else:
@@ -298,6 +299,7 @@ class Fightclub(commands.Cog):
                 team_2_users += 1
             if entry['userid'] == 164546159140929538:
                 #never used; god_emperor = entry['elo']
+                pass
         total_aggro_r = self.ratio(total_aggro_w, total_aggro_l)
         total_def_r = self.ratio(total_def_w, total_def_l)
         top_10_aggro = await self.get_member_string(

--- a/cogs/logging.py
+++ b/cogs/logging.py
@@ -57,7 +57,7 @@ class Logging(commands.Cog):
 
             report_id = await self.bot.pg_controller.add_user_report(
                 message.author.id, content)
-            mod_info = self.bot.get_channel(self.bot.mod_info)
+            mod_info = self.bot.get_channel(259728514914189312)
             if content.startswith('!suggest'):
                 local_embed = discord.Embed(
                     title=f'Suggestion:',
@@ -95,7 +95,7 @@ class Logging(commands.Cog):
     @commands.Cog.listener()
     async def on_member_update(self, before, after):
         if before.roles != after.roles:
-            mod_info = self.bot.get_channel(self.bot.mod_info)
+            mod_info = self.bot.get_channel(259728514914189312)
             time = self.bot.timestamp()
             join = after.joined_at.strftime('%b %d %Y %H:%M')
             role_diff = set(after.roles) - (set(before.roles))

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -161,9 +161,7 @@ class Moderation(commands.Cog):
         Examples
         --------
         blgu add 1298371,18972398,182739817
-        blgu add report 10
-        blgu rm 1298371,18972398,182739817
-        blgu rm report 10
+        blgu rm 11
 
         Parameters
         ----------

--- a/cogs/utils/functions.py
+++ b/cogs/utils/functions.py
@@ -151,7 +151,7 @@ def get_member(ctx, argument: str):
         return None
 
 
-def extract_id(argument: str):
+def extract_id(argument: str, strict: bool=True):
     """Extract id from argument."""
     """
     Parameters
@@ -165,7 +165,7 @@ def extract_id(argument: str):
         the bare id
     """
     ex = ''.join(list(filter(str.isdigit, str(argument))))
-    if len(ex) < 15:
+    if len(ex) < 15 and strict:
         return None
     return ex
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ asyncpg==0.18.2
 PyYAML==5.1.2
 discord.py==1.0.1
 yappi==1.0 
+gila==0.3.0


### PR DESCRIPTION
Migrated to gila because yay

made reports anonymous and added a suggestion ability if you start your dm with `!suggest` (falls back to a normal report)
you can get the id of a reporter via `-id #` where # is the report number.
You can also ban them from the bot directly via `-blgu add #` where # is the report number or a user id.

made the blacklisting embeds a little more uniform
I think the magic numbers are correct. Here's hoping