### PR TITLE
Feature/depin

### DIFF
--- a/cogs/channels.py
+++ b/cogs/channels.py
@@ -1,17 +1,19 @@
 """
 This cog will create messages that will manage channel perms with reacts.
 """
-import discord
-import datetime
-from asyncpg.exceptions import UniqueViolationError
 from collections import defaultdict
-from .utils import helpers, checks
+import datetime
+
+from asyncpg.exceptions import UniqueViolationError
+import discord
 from discord.ext import commands
+
+from .utils import helpers, checks
+from .utils.functions import add_perms, remove_perms
 
 
 class Channels(commands.Cog):
-    """
-    """
+    """Commands for the channel message functionality."""
 
     def __init__(self, bot):
         super().__init__()
@@ -293,7 +295,7 @@ class Channels(commands.Cog):
                 f'**{time} | REACTION SPAM:** {user} has reacted {reacts} '\
                 f'times today on the permission message for #{channel}'
             )
-        await self.add_perms(user, channel)
+        await add_perms(self.bot, user, channel)
         await self.bot.pg_controller.add_user_chanreact(payload.user_id, payload.channel_id, payload.message_id, target_channel)
 
     @commands.Cog.listener()
@@ -310,23 +312,6 @@ class Channels(commands.Cog):
         user = self.bot.get_user(payload.user_id)
         if user.bot:
             return
-        await self.remove_perms(user, channel)
+        await remove_perms(self.bot, user, channel)
         await self.bot.pg_controller.rm_user_chanreact(payload.user_id, target_channel, payload.channel_id)
 
-    async def add_perms(self, user, channel):
-        """
-        Adds a user to channels perms
-        """
-        try:
-            await channel.set_permissions(user, read_messages=True)
-        except Exception as e:
-            self.bot.logger.warning(f'{e}')
-
-    async def remove_perms(self, user, channel):
-        """
-        removes a users perms on a channel
-        """
-        try:
-            await channel.set_permissions(user, read_messages=False)
-        except Exception as e:
-            self.bot.logger.warning(f'{e}')

--- a/cogs/janitor.py
+++ b/cogs/janitor.py
@@ -295,6 +295,15 @@ class Janitor(commands.Cog):
         """
         help? lmao bruh thats it. just run it at the end of the month and u good
         """
+        try:
+            confirm = await helpers.custom_confirm(
+                ctx,
+                f'```Begin the clearing of all exp roles. This may take a long time.```'
+            )
+            if not confirm:
+                return
+        except Exception:
+            return
         roles_to_wipe = ['member', 'active', 'regular', 'contributor', 'addicted', 'insomniac', 'no-lifer']
         color_roles = ['-2-', '-5-', '-10-', '-15-', '-20-', '-25-']
         all_roles = ctx.channel.guild.roles

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -6,7 +6,7 @@ import discord
 from discord import HTTPException
 from discord.ext import commands
 from .utils import helpers, checks
-from .utils.functions import GeneralMember, extract_id
+from .utils.functions import GeneralMember, extract_id, remove_perms, add_perms
 
 
 class ActionReason(commands.Converter):
@@ -50,7 +50,7 @@ class Moderation(commands.Cog):
         except Exception as e:
             self.bot.logger.warn(f'Unable to remove pins: {e}')
             await ctx.message.add_reaction(r'❌')
-        
+
 
     @commands.command(aliases=['message', 'dm', 'pm'])
     @checks.has_permissions(manage_roles=True)
@@ -141,7 +141,7 @@ class Moderation(commands.Cog):
             for target_channel in r:
                 try:
                     target_channel = self.bot.get_channel(target_channel)
-                    await self.remove_perms(member, target_channel)
+                    await remove_perms(self.bot, member, target_channel)
                     removed_from_channels.append(target_channel.name)
                 except (HTTPException, AttributeError) as e:
                     self.bot.logger.warning(f'Error removing user from channel!: {target_channel} {e}')  # noqa
@@ -178,7 +178,7 @@ class Moderation(commands.Cog):
             for target_channel in r:
                 try:
                     target_channel = self.bot.get_channel(target_channel)
-                    await self.add_perms(member, target_channel)
+                    await add_perms(self.bot, member, target_channel)
                     removed_from_channels.append(target_channel.name)
                 except (HTTPException, AttributeError) as e:
                     self.bot.logger.warning(f'Error adding user to channel!: {target_channel} {e}')  # noqa
@@ -191,24 +191,6 @@ class Moderation(commands.Cog):
         ret = ', '.join(removed_from_channels)
         reply += f'**User: {member.name}#{member.discriminator}: **Successfully added to channels: ``` {ret}```'  # noqa
         await ctx.send(f'**{time}** | {reply}')
-
-    async def add_perms(self, user, channel):
-        """
-        Adds a user to channels perms
-        """
-        try:
-            await channel.set_permissions(user, read_messages=True)
-        except Exception as e:
-            self.bot.logger.warning(f'{e}')
-
-    async def remove_perms(self, user, channel):
-        """
-        removes a users perms on a channel
-        """
-        try:
-            await channel.set_permissions(user, read_messages=False)
-        except Exception as e:
-            self.bot.logger.warning(f'{e}')
 
     """
     BLACKLIST

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -28,6 +28,30 @@ class Moderation(commands.Cog):
         super().__init__()
         self.bot = bot
 
+    @commands.command(aliases=['pinclear', 'removepins'])
+    @checks.has_permissions(manage_channels=True)
+    @commands.guild_only()
+    async def clearpins(self, ctx):
+        """Clear all the pins from the current channel."""
+        try:
+            confirm = await helpers.custom_confirm(
+                ctx,
+                f'```Clear all pins from current channel.```'
+            )
+            if not confirm:
+                return
+        except Exception:
+            return
+        try:
+            messages = await ctx.channel.pins()
+            for m in messages:
+                await m.unpin()
+            await ctx.message.add_reaction(r'✅')
+        except Exception as e:
+            self.bot.logger.warn(f'Unable to remove pins: {e}')
+            await ctx.message.add_reaction(r'❌')
+        
+
     @commands.command(aliases=['message', 'dm', 'pm'])
     @checks.has_permissions(manage_roles=True)
     @commands.guild_only()

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -28,6 +28,42 @@ class Moderation(commands.Cog):
         super().__init__()
         self.bot = bot
 
+    @commands.command(aliases=['message', 'dm', 'pm'])
+    @checks.has_permissions(manage_roles=True)
+    @commands.guild_only()
+    async def privatemessage(self, ctx, member: GeneralMember, *, content: str):
+        """Respond to a user via yinbot.
+        """
+        try:
+            message = ctx.message
+            await member.create_dm()
+            channel = member.dm_channel
+        except Exception as e:
+            self.bot.logger.warn(f'Unable to PM user: {e}')
+            await ctx.message.add_reaction(r'❌')
+            return 
+        desc = ''
+        if message.attachments:
+            for f in message.attachments:
+                desc += f'{f.url}\n'
+
+        local_embed = discord.Embed(
+            title=f'Message to {member.mention} from the staff team',
+            description=content
+        )
+        if desc:
+            local_embed.add_field(
+                name='Attachments',
+                value=f'{desc}',
+                inline=True
+            )
+        try:
+            pm = await channel.send(embed=local_embed)
+            await ctx.message.add_reaction(r'✅')
+        except Exception:
+            await ctx.send(f'Unable to PM user: {e}', delete_after=5)
+            await ctx.message.add_reaction(r'❌')
+
     @commands.command()
     @checks.has_permissions(manage_messages=True)
     async def purge(self, ctx, *args, mentions=None):

--- a/cogs/utils/functions.py
+++ b/cogs/utils/functions.py
@@ -222,6 +222,34 @@ def get_role(ctx, argument: str):
     except Exception:
         return False
 
+async def add_perms(bot, user, channel):
+    """
+    Adds a user to channels perms
+    """
+    try:
+        await channel.set_permissions(user, read_messages=True)
+    except Exception as e:
+        bot.logger.warning(f'{e}')
+
+async def deny_perms(bot, user, channel):
+    """
+    Sets perm to deny a users perms on a channel
+    """
+    try:
+        await channel.set_permissions(user, read_messages=False)
+    except Exception as e:
+        bot.logger.warning(f'{e}')
+
+async def remove_perms(bot, user, channel):
+    """
+    removes a users perms on a channel
+    """
+    try:
+        await channel.set_permissions(user, read_messages=None)
+    except Exception as e:
+        bot.logger.warning(f'{e}')
+
+
 # end of code
 
 # end of file

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 typing==3.6.2
 asyncpg==0.18.2
 PyYAML==5.1.2
-discord.py==1.0.1
+discord.py==1.2.5
 yappi==1.0 
-gila==0.3.0
+gila==0.4.0


### PR DESCRIPTION
I have been meaning to write the function but especially with the new channel most likely coming online, it would be nice to be able to mass de-pin all messages from a channel. This would be useful in the palette event too.

My idea was for the new meta channel, we could pin the current topic summaries, votes, and results; once a consensus is reached we post to update board, then we can unpin everything once the new discussion starts.